### PR TITLE
Sonic.* dll не подключаются к проекту автоматически, если находятся в net40, а сам проект на 4.5

### DIFF
--- a/src/Inceptum.Messaging.Castle/MessagingFacility.cs
+++ b/src/Inceptum.Messaging.Castle/MessagingFacility.cs
@@ -233,7 +233,7 @@ namespace Inceptum.Messaging.Castle
             foreach (var factoryHandler in m_SerializerFactoryWaitList.ToArray())
             {
                 if(tryRegisterSerializerFactory(factoryHandler))
-                    m_SerializerWaitList.Remove(factoryHandler);
+                    m_SerializerFactoryWaitList.Remove(factoryHandler);
             }
         }
         /// <summary>

--- a/src/Inceptum.Messaging.Sonic/Inceptum.Messaging.Sonic.nuspec
+++ b/src/Inceptum.Messaging.Sonic/Inceptum.Messaging.Sonic.nuspec
@@ -16,6 +16,6 @@
 		</dependencies>  
 	</metadata>
 	<files>
-		<file src="..\libs\Sonic\*.*" target="lib\net40" />
+		<file src="..\libs\Sonic\*.*" target="lib\net45" />
 	</files>
 </package>


### PR DESCRIPTION
Сборки Sonic.* автоматически не подключаются к проекту (не попадают в bin), если располагаются в net40, а сам Inceptum.Messaging.Sonic.dll в net45