### PR TITLE
Sonic.* dll должны находится в каталоге net45, если Target Framework проекта = 4.5

### DIFF
--- a/src/Inceptum.Messaging.Sonic/Inceptum.Messaging.Sonic.nuspec
+++ b/src/Inceptum.Messaging.Sonic/Inceptum.Messaging.Sonic.nuspec
@@ -17,5 +17,6 @@
 	</metadata>
 	<files>
 		<file src="..\libs\Sonic\*.*" target="lib\net40" />
+    <file src="..\libs\Sonic\*.*" target="lib\net45" />
 	</files>
 </package>


### PR DESCRIPTION
Sonic.* dll а каталоге net40 оставлены для совместимости

p.s. предыдущий pull request по ошибке удалил 