### PR TITLE
Scenario: Send message to queue and specify replyTo

### DIFF
--- a/src/Inceptum.Messaging.RabbitMq/RabbitMqSession.cs
+++ b/src/Inceptum.Messaging.RabbitMq/RabbitMqSession.cs
@@ -257,5 +257,17 @@ namespace Inceptum.Messaging.RabbitMq
             }
             
         }
+
+
+        public void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            send(destination, message, properties =>
+            {
+                if (ttl > 0) properties.Expiration = ttl.ToString(CultureInfo.InvariantCulture);
+                properties.ReplyTo = replyTo.Destination;
+                if (replyTo.CorrelationId != null)
+                    properties.CorrelationId = replyTo.CorrelationId;
+            });
+        }
     }
 }

--- a/src/Inceptum.Messaging.Sonic/SonicSessionWrapper.cs
+++ b/src/Inceptum.Messaging.Sonic/SonicSessionWrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Inceptum.Messaging.Contract;
 using Inceptum.Messaging.Transports;
 using Sonic.Jms;
 using Destination = Inceptum.Messaging.Contract.Destination;
@@ -101,6 +102,13 @@ namespace Inceptum.Messaging.Sonic
         public Destination CreateTemporaryDestination()
         {
             return m_Instance.CreateTemporaryDestination();
+        }
+
+
+        public void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            ensureSessionIsCreated(destination);
+            m_Instance.Send(destination, message, ttl, replyTo);
         }
     }
 }

--- a/src/Inceptum.Messaging.Weblogic/WeblogicSession.cs
+++ b/src/Inceptum.Messaging.Weblogic/WeblogicSession.cs
@@ -196,5 +196,19 @@ namespace Inceptum.Messaging.Weblogic
         {
             return m_Connection.CreateSession(Constants.SessionMode.AUTO_ACKNOWLEDGE);
         }
+
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        public void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            ensureSessionIsCreated();
+            send(destination, message, ttl, tuneMessage =>
+            {
+                tuneMessage.JMSReplyTo = createDestination(replyTo.Destination);
+                if (replyTo.CorrelationId != null)
+                    tuneMessage.JMSCorrelationID = replyTo.CorrelationId;
+            });
+        }
+
     }
 }

--- a/src/Inceptum.Messaging/Contract/IMessagingEngine.cs
+++ b/src/Inceptum.Messaging/Contract/IMessagingEngine.cs
@@ -35,6 +35,7 @@ namespace Inceptum.Messaging.Contract
         ISerializationManager SerializationManager { get; }
         IDisposable SubscribeOnTransportEvents(TransportEventHandler handler);
         void Send<TMessage>(TMessage message, Endpoint endpoint, string processingGroup = null, Dictionary<string, string> headers = null);
+
         void Send<TMessage>(TMessage message, Endpoint endpoint, int ttl, string processingGroup = null, Dictionary<string, string> headers = null);
         void Send(object message, Endpoint endpoint, string processingGroup = null, Dictionary<string, string> headers = null);
         Destination CreateTemporaryDestination(string transportId, string processingGroup);
@@ -53,6 +54,9 @@ namespace Inceptum.Messaging.Contract
 
         bool VerifyEndpoint(Endpoint endpoint, EndpointUsage usage, bool configureIfRequired, out string error);
         string GetStatistics();
+
+        void Send<TMessage>(TMessage message, Endpoint endpoint, int ttl, ReplyTo replyTo, string processingGroup = null, Dictionary<string, string> headers = null);
+        void Send<TMessage>(TMessage message, Endpoint endpoint, ReplyTo replyTo, string processingGroup = null, Dictionary<string, string> headers = null);
     }
 
     [Flags]

--- a/src/Inceptum.Messaging/Contract/ReplyTo.cs
+++ b/src/Inceptum.Messaging/Contract/ReplyTo.cs
@@ -1,0 +1,40 @@
+﻿namespace Inceptum.Messaging.Contract
+{
+    /// <summary>
+    /// Information for response
+    /// </summary>
+    public struct ReplyTo
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="destination"></param>
+        public ReplyTo(string destination)
+            : this()
+        {
+            Destination = destination;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="destination"></param>
+        /// <param name="correlationId"></param>
+        public ReplyTo(string destination, string correlationId) 
+            : this()
+        {
+            Destination = destination;
+            CorrelationId = correlationId;
+        }
+
+        /// <summary>
+        /// Queue name with queue://
+        /// </summary>
+        public string Destination { get; set; }
+        
+        /// <summary>
+        /// ReplyTo CorrelationId
+        /// </summary>
+        public string CorrelationId { get; set; }
+    }
+}

--- a/src/Inceptum.Messaging/InMemory/InMemorySession.cs
+++ b/src/Inceptum.Messaging/InMemory/InMemorySession.cs
@@ -89,5 +89,13 @@ namespace Inceptum.Messaging.InMemory
             m_Scheduler.Dispose();
             m_IsDisposed = true;
         }
+
+        public void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            message.Headers["ReplyTo"] = replyTo.Destination;
+            if (replyTo.CorrelationId != null)
+                message.Headers["CorrelationId"] = replyTo.CorrelationId;
+            m_Transport[destination].OnNext(message);
+        }
     }
 }

--- a/src/Inceptum.Messaging/Inceptum.Messaging.csproj
+++ b/src/Inceptum.Messaging/Inceptum.Messaging.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Configuration\TransportsCollection.cs" />
     <Compile Include="Contract\Endpoint.cs" />
     <Compile Include="Contract\IMessagingEngine.cs" />
+    <Compile Include="Contract\ReplyTo.cs" />
     <Compile Include="Contract\TransportConstants.cs" />
     <Compile Include="Contract\TransportException.cs" />
     <Compile Include="Contract\TransportOutdatedException.cs" />

--- a/src/Inceptum.Messaging/ProcessingGroup.cs
+++ b/src/Inceptum.Messaging/ProcessingGroup.cs
@@ -4,6 +4,7 @@ using System.Reactive.Disposables;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Inceptum.Messaging.Contract;
 using Inceptum.Messaging.Transports;
 using Inceptum.Messaging.Utils;
 
@@ -161,6 +162,12 @@ namespace Inceptum.Messaging
         public void Send(IMessagingSession messagingSession, string publish, BinaryMessage message, int ttl)
         {
             messagingSession.Send(publish,message,ttl);
+            Interlocked.Increment(ref m_SentMessages);
+        }
+
+        public void Send(IMessagingSession messagingSession, string publish, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            messagingSession.Send(publish, message, ttl, replyTo);
             Interlocked.Increment(ref m_SentMessages);
         }
     }

--- a/src/Inceptum.Messaging/ProcessingGroupManager.cs
+++ b/src/Inceptum.Messaging/ProcessingGroupManager.cs
@@ -158,7 +158,6 @@ namespace Inceptum.Messaging
 
         }
 
-
         private void scheduleSubscription(Action<int> subscribe, int attemptCount)
         {
             lock (m_ResubscriptionSchedule)
@@ -272,6 +271,15 @@ namespace Inceptum.Messaging
                 processingGroup.Dispose();
             }
             processDeferredAcknowledgements(true);
+        }
+
+        public void Send(Endpoint endpoint, BinaryMessage message, int ttl, string processingGroup, ReplyTo replyTo)
+        {
+            var group = getProcessingGroup(processingGroup);
+            var session = m_TransportManager.GetMessagingSession(endpoint.TransportId, getSessionName(group, 0));
+
+            group.Send(session, endpoint.Destination.Publish, message, ttl, replyTo);
+
         }
     }
 }

--- a/src/Inceptum.Messaging/ResolvedTransport.cs
+++ b/src/Inceptum.Messaging/ResolvedTransport.cs
@@ -194,5 +194,10 @@ namespace Inceptum.Messaging
         {
             return MessagingSession.CreateTemporaryDestination();
         }
+
+        public void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo)
+        {
+            MessagingSession.Send(destination, message, ttl, replyTo);
+        }
     }
 }

--- a/src/Inceptum.Messaging/Transports/ITransport.cs
+++ b/src/Inceptum.Messaging/Transports/ITransport.cs
@@ -13,6 +13,7 @@ namespace Inceptum.Messaging.Transports
     public interface IMessagingSession : IDisposable
     {
         void Send(string destination, BinaryMessage message, int ttl);
+        void Send(string destination, BinaryMessage message, int ttl, ReplyTo replyTo);
         RequestHandle SendRequest(string destination, BinaryMessage message, Action<BinaryMessage> callback);
         IDisposable RegisterHandler(string destination, Func<BinaryMessage, BinaryMessage> handler, string messageType);
         IDisposable Subscribe(string destination, Action<BinaryMessage, Action<bool>> callback, string messageType);


### PR DESCRIPTION
External service requires that clients pass queue for answer and correlationId (for some requests)
It can't work synchronously so i can't use request / response
Current MessagingEngine doesn't provide access to ReplyTo field

Pull request provides implementation for  concrete scenario.
Perhaps better way implement something like CommonProperties to aggregate all common parameters for sending messages if there are any except replyTo and correlationId
