### PR TITLE
enabled autorecovery feature in rabbitmq transport

### DIFF
--- a/src/Inceptum.Messaging.RabbitMq/RabbitMqTransport.cs
+++ b/src/Inceptum.Messaging.RabbitMq/RabbitMqTransport.cs
@@ -46,6 +46,9 @@ namespace Inceptum.Messaging.RabbitMq
                 f.UserName = username;
                 f.Password = password;
 
+                f.AutomaticRecoveryEnabled = true;
+                f.NetworkRecoveryInterval = TimeSpan.FromSeconds(5);//it's default value
+
                 if (Uri.TryCreate(brokerName, UriKind.Absolute, out uri))
                 {
                     f.Uri = brokerName;


### PR DESCRIPTION
there was a bug with two nodes rmq cluster. When one node loose another (break connection, for example) consumer stop getting messages.
this is a quick fix.