### PR TITLE
Remove action delegate from deffered acknowledgements list on session close.

### DIFF
--- a/src/Inceptum.Messaging.RabbitMq/Consumer.cs
+++ b/src/Inceptum.Messaging.RabbitMq/Consumer.cs
@@ -22,10 +22,17 @@ namespace Inceptum.Messaging.RabbitMq
             {
                 m_Callback(properties, body, ack =>
                 {
-                    if (ack)
-                        Model.BasicAck(deliveryTag, false);
-                    else
-                        Model.BasicNack(deliveryTag, false, true);
+                    try
+                    {
+                        if (ack)
+                            Model.BasicAck(deliveryTag, false);
+                        else
+                            Model.BasicNack(deliveryTag, false, true);
+                    }
+                    catch (RabbitMQ.Client.Exceptions.AlreadyClosedException e)
+                    {
+                        throw new MessagingSessionClosedException("Consumer failed to handle ack with value " + ack + "", e);
+                    }
                 });
             }
             catch (Exception e)

--- a/src/Inceptum.Messaging.RabbitMq/SharedConsumer.cs
+++ b/src/Inceptum.Messaging.RabbitMq/SharedConsumer.cs
@@ -65,11 +65,18 @@ namespace Inceptum.Messaging.RabbitMq
                     {
                         callback(properties, body,ack =>
                             {
-                                if(ack)
-                                    Model.BasicAck(deliveryTag, false);
-                                else
-                                    //TODO: allow callback to decide whether to redeliver
-                                    Model.BasicNack(deliveryTag, false,true);
+                                try
+                                {
+                                    if (ack)
+                                        Model.BasicAck(deliveryTag, false);
+                                    else
+                                        //TODO: allow callback to decide whether to redeliver
+                                        Model.BasicNack(deliveryTag, false, true);
+                                }
+                                catch (RabbitMQ.Client.Exceptions.AlreadyClosedException e)
+                                {
+                                    throw new MessagingSessionClosedException("Failed to handle ack with value " + ack + "", e);
+                                }
                             });
                         
                     }

--- a/src/Inceptum.Messaging.RabbitMq/SharedConsumer.cs
+++ b/src/Inceptum.Messaging.RabbitMq/SharedConsumer.cs
@@ -75,7 +75,7 @@ namespace Inceptum.Messaging.RabbitMq
                                 }
                                 catch (RabbitMQ.Client.Exceptions.AlreadyClosedException e)
                                 {
-                                    throw new MessagingSessionClosedException("Failed to handle ack with value " + ack + "", e);
+                                    throw new MessagingSessionClosedException("SharedConsumer failed to handle ack with value " + ack + "", e);
                                 }
                             });
                         

--- a/src/Inceptum.Messaging/Inceptum.Messaging.csproj
+++ b/src/Inceptum.Messaging/Inceptum.Messaging.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\SerializationManager.cs" />
     <Compile Include="ProcessingGroupManager.cs" />
+    <Compile Include="MessagingSessionClosedException.cs" />
     <Compile Include="Transports\BinaryMessage.cs" />
     <Compile Include="Transports\ITransport.cs" />
     <Compile Include="Transports\RequestHandle.cs" />

--- a/src/Inceptum.Messaging/MessagingSessionClosedException.cs
+++ b/src/Inceptum.Messaging/MessagingSessionClosedException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Inceptum.Messaging
+{
+    public class MessagingSessionClosedException : Exception
+    {
+        public MessagingSessionClosedException()
+        {
+        }
+
+        public MessagingSessionClosedException(string message) : base(message)
+        {
+        }
+
+        public MessagingSessionClosedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Inceptum.Messaging/ProcessingGroupManager.cs
+++ b/src/Inceptum.Messaging/ProcessingGroupManager.cs
@@ -265,6 +265,26 @@ namespace Inceptum.Messaging
             return stats.ToString();
         }
 
+        #region Internal Statistics for tests
+
+        internal struct InternalStatistics
+        {
+            public int DeferredAcknowledgements;
+        }
+
+        internal InternalStatistics GetInternalStatistics()
+        {
+            lock (m_DeferredAcknowledgements)
+            {
+                return new InternalStatistics
+                {
+                    DeferredAcknowledgements = m_DeferredAcknowledgements.Count
+                };
+            }
+        }
+
+        #endregion
+
         public void Dispose()
         {
             m_IsDisposing = true;


### PR DESCRIPTION
Enhanced `Inceptum.Messaging` with `MessagingSessionClosedException` exception class,
which is handled by `ProcessingGroupManager.processDeferredAcknowledgements` to avoid
trying to acknowledge messages from closed connections.

Updated `Inceptum.Messaging.RabbitMq.SharedConsumer` to throw `MessagingSessionClosedException`
if underlying RMQ Model throws `AlreadyClosedException`.